### PR TITLE
Refactor code to use promises

### DIFF
--- a/src/content/js/content_script.js
+++ b/src/content/js/content_script.js
@@ -463,7 +463,8 @@ var getElementValue = function(el, selector) {
     }
 }
 
-var init = function (settings) {
+async function init() {
+	const settings = await getSettings();
     if (!settings.enabled) {
         return;
     }
@@ -591,4 +592,4 @@ var init = function (settings) {
         });
 };
 
-getSettings(init);
+init();

--- a/src/content/js/core.js
+++ b/src/content/js/core.js
@@ -313,9 +313,8 @@ async function getSettings() {
  * Checks for potentially missing properties in the settings object (caused by new properties being added on new versions of the code) 
  * and create those properties as defaults or from the defaultSettings object.
  * @param {Settings} data - settings to save
- * @param {function} callback - function to call on completion
  */
-async function setSettings(data, callback) {
+async function setSettings(data) {
     if (!data.hasOwnProperty('enabled')) {
         data.enabled = true;
     }
@@ -332,9 +331,7 @@ async function setSettings(data, callback) {
     obj['sonarrRadarrLidarrAutosearchSettings'] = data;
 
     await browser.storage.sync.set(obj);
-    if (typeof callback === "function") {
-        callback(data);
-    }
+    return data;
 };
 
 /**
@@ -408,7 +405,7 @@ async function callApi(request, callback) {
 
     var url = getApiUrl(site, request.endpoint);
 
-    $.getJSON(url, function(data) {
+    $.getJSON(url, async function(data) {
         switch (request.endpoint) {
             // if this is a 'Version' call try to update settings if with version specific data
             case 'Version':
@@ -436,16 +433,15 @@ async function callApi(request, callback) {
                     }
                 }
 
-                setSettings(settings, function (settings) {
-                    if (typeof callback === "function") {
-                        callback({
-                            data: data,
-                            request: request,
-                            success: true,
-                            error: null
-                        });
-                    }
-                });
+                await setSettings(settings);
+                if (typeof callback === "function") {
+                    callback({
+                        data: data,
+                        request: request,
+                        success: true,
+                        error: null
+                    });
+                }
                 break;
 
             default:

--- a/src/content/js/options.js
+++ b/src/content/js/options.js
@@ -134,34 +134,33 @@ var initialiseBasicForm = function (settings) {
         });
     
         // api key test buttons
-        $('#' + site.id + 'ApiKeyTest').on('click', function () {
+        $('#' + site.id + 'ApiKeyTest').on('click', async function () {
             var siteId = $(this).attr('data-site-id');
     
             setTestButtonIcon(siteId, 'Progress');
 
             $('#' + siteId + 'ApiTestMessage').hide();
-            callApi({ siteId: siteId, endpoint: 'Version' }, async function(response) {
-                if (response.success) {
-                    setTestButtonIcon(siteId, "Worked");
+            const response = await callApi({ siteId: siteId, endpoint: 'Version' });
+            if (response.success) {
+                setTestButtonIcon(siteId, "Worked");
 
-                    $('#' + siteId + 'ApiTestMessage')
-                        .removeClass('bg-danger')
-                        .addClass('bg-success')
-                        .html(`Success! Detected version ${response.data.version}`)
-                        .show();
-                    const settings = await getSettings();
-                    updateAdvancedForm(settings);
-                } else {
-                    setTestButtonIcon(siteId, "Failed");
-                    $('#' + siteId + 'ApiTestMessage')
-                        .removeClass('bg-success')
-                        .addClass('bg-danger')
-                        .html('Failed, please double check the domain and API key')
-                        .show();
-                }
+                $('#' + siteId + 'ApiTestMessage')
+                    .removeClass('bg-danger')
+                    .addClass('bg-success')
+                    .html(`Success! Detected version ${response.data.version}`)
+                    .show();
+                const settings = await getSettings();
+                updateAdvancedForm(settings);
+            } else {
+                setTestButtonIcon(siteId, "Failed");
+                $('#' + siteId + 'ApiTestMessage')
+                    .removeClass('bg-success')
+                    .addClass('bg-danger')
+                    .html('Failed, please double check the domain and API key')
+                    .show();
+            }
 
-                // alert?
-            });
+            // alert?
         });
     }); 
 };
@@ -406,7 +405,7 @@ async function setSettingsPropertiesFromDebugForm() {
 /**
  * Listen for storage changes
  */
-browser.storage.onChanged.addListener(function(changes, area) {
+browser.storage.onChanged.addListener(async function(changes, area) {
     let changedItems = Object.keys(changes);
 
     for (let item of changedItems) {
@@ -431,18 +430,17 @@ browser.storage.onChanged.addListener(function(changes, area) {
                 oldSite.autoPopAdvancedFromApi != newSite.autoPopAdvancedFromApi)) {
                     log('Advanced settings update check required, calling version API');
 
-                    callApi({ siteId: newSite.id, endpoint: 'Version' }, async function(response) {
-                        if (response.success) {
-                            log([`API call succeeded, updating advanced settings for ${newSite.id}`, response]);
+                    const response = await callApi({ siteId: newSite.id, endpoint: 'Version' });
+                    if (response.success) {
+                        log([`API call succeeded, updating advanced settings for ${newSite.id}`, response]);
 
-                            const settings = await getSettings();
-                            updateAdvancedForm(settings);
-                        } else {
-                            log(['API call failed', response]);
-                        }
+                        const settings = await getSettings();
+                        updateAdvancedForm(settings);
+                    } else {
+                        log(['API call failed', response]);
+                    }
 
-                        // notify?
-                    });
+                    // notify?
                 }
         }
     }

--- a/src/content/js/options.js
+++ b/src/content/js/options.js
@@ -140,7 +140,7 @@ var initialiseBasicForm = function (settings) {
             setTestButtonIcon(siteId, 'Progress');
 
             $('#' + siteId + 'ApiTestMessage').hide();
-            callApi({ siteId: siteId, endpoint: 'Version' }, function(response) {
+            callApi({ siteId: siteId, endpoint: 'Version' }, async function(response) {
                 if (response.success) {
                     setTestButtonIcon(siteId, "Worked");
 
@@ -149,7 +149,8 @@ var initialiseBasicForm = function (settings) {
                         .addClass('bg-success')
                         .html(`Success! Detected version ${response.data.version}`)
                         .show();
-                    getSettings(updateAdvancedForm);
+                    const settings = await getSettings();
+                    updateAdvancedForm(settings);
                 } else {
                     setTestButtonIcon(siteId, "Failed");
                     $('#' + siteId + 'ApiTestMessage')
@@ -355,55 +356,51 @@ var initialiseDebugForm = function (settings) {
 /**
  * Update settings from the settings tab form fields
  */
-var setSettingsPropertiesFromForm = function () {
-    getSettings(function(settings) {
-        for (var i = 0; i < settings.sites.length; i++) {
-            settings.sites[i].domain = $('#' + settings.sites[i].id + 'Domain').val();
-            settings.sites[i].apiKey = $('#' + settings.sites[i].id + 'ApiKey').val();
-            settings.sites[i].enabled = $('#toggle-' + settings.sites[i].id).prop('checked');
-        }
+async function setSettingsPropertiesFromForm() {
+    const settings = await getSettings();
+    for (var i = 0; i < settings.sites.length; i++) {
+        settings.sites[i].domain = $('#' + settings.sites[i].id + 'Domain').val();
+        settings.sites[i].apiKey = $('#' + settings.sites[i].id + 'ApiKey').val();
+        settings.sites[i].enabled = $('#toggle-' + settings.sites[i].id).prop('checked');
+    }
 
-        setSettings(settings);
-    });    
+    setSettings(settings);
 };
 
 /**
  * Update settings from the advanced settings tab form fields
  */
-var setSettingsPropertiesFromAdvancedForm = function () {
-    getSettings(function(settings) {
-        for (var i = 0; i < settings.sites.length; i++) {
-            settings.sites[i].searchPath = $('#' + settings.sites[i].id + 'SearchPath').val();
-            settings.sites[i].searchInputSelector = $('#' + settings.sites[i].id + 'SearchInputSelector').val();
-            settings.sites[i].autoPopAdvancedFromApi = $('#toggle-' + settings.sites[i].id + '-advanced').prop('checked');
-        }
+async function setSettingsPropertiesFromAdvancedForm() {
+    const settings = await getSettings();
+    for (var i = 0; i < settings.sites.length; i++) {
+        settings.sites[i].searchPath = $('#' + settings.sites[i].id + 'SearchPath').val();
+        settings.sites[i].searchInputSelector = $('#' + settings.sites[i].id + 'SearchInputSelector').val();
+        settings.sites[i].autoPopAdvancedFromApi = $('#toggle-' + settings.sites[i].id + '-advanced').prop('checked');
+    }
 
-        setSettings(settings);
-    });
+    setSettings(settings);
 };
 
 /**
  * Update settings from the integrations tab form fields
  */
-var setSettingsPropertiesFromIntegrationsForm = function () {
-    getSettings(function(settings) {
-        for (var i = 0; i < settings.integrations.length; i++) {
-            settings.integrations[i].enabled = $('#toggle-' + settings.integrations[i].name).prop('checked');
-        }
+async function setSettingsPropertiesFromIntegrationsForm() {
+    const settings = await getSettings();
+    for (var i = 0; i < settings.integrations.length; i++) {
+        settings.integrations[i].enabled = $('#toggle-' + settings.integrations[i].name).prop('checked');
+    }
 
-        setSettings(settings);
-    });
+    setSettings(settings);
 };
 
 /**
  * Update settings from the debug tab form fields
  */
-var setSettingsPropertiesFromDebugForm = function () {
-    getSettings(function(settings) {
-        settings.debug = $('#toggle-debug').prop('checked');
+async function setSettingsPropertiesFromDebugForm() {
+    const settings = await getSettings();
+    settings.debug = $('#toggle-debug').prop('checked');
 
-        setSettings(settings);
-    });
+    setSettings(settings);
 };
 
 /**
@@ -434,11 +431,12 @@ browser.storage.onChanged.addListener(function(changes, area) {
                 oldSite.autoPopAdvancedFromApi != newSite.autoPopAdvancedFromApi)) {
                     log('Advanced settings update check required, calling version API');
 
-                    callApi({ siteId: newSite.id, endpoint: 'Version' }, function(response) {
+                    callApi({ siteId: newSite.id, endpoint: 'Version' }, async function(response) {
                         if (response.success) {
                             log([`API call succeeded, updating advanced settings for ${newSite.id}`, response]);
 
-                            getSettings(updateAdvancedForm);
+                            const settings = await getSettings();
+                            updateAdvancedForm(settings);
                         } else {
                             log(['API call failed', response]);
                         }
@@ -450,14 +448,13 @@ browser.storage.onChanged.addListener(function(changes, area) {
     }
 });
 
-$(function () {
+$(async function () {
     // initialise page on load
-    getSettings(function(settings) {
-        initialiseBasicForm(settings);
-        initialiseAdvancedForm(settings);
-        initialiseIntegrationsForm(settings);
-        initialiseDebugForm(settings);
-    });
+    const settings = await getSettings();
+    initialiseBasicForm(settings);
+    initialiseAdvancedForm(settings);
+    initialiseIntegrationsForm(settings);
+    initialiseDebugForm(settings);
 
     // deactivate all other tabs on click. this shouldn't be required, but bootstrap 5 beta seems a bit buggy with tab deactivation.
     $('.tab-pane').on('click', function() {

--- a/src/content/js/options.js
+++ b/src/content/js/options.js
@@ -364,7 +364,7 @@ async function setSettingsPropertiesFromForm() {
         settings.sites[i].enabled = $('#toggle-' + settings.sites[i].id).prop('checked');
     }
 
-    setSettings(settings);
+    await setSettings(settings);
 };
 
 /**
@@ -378,7 +378,7 @@ async function setSettingsPropertiesFromAdvancedForm() {
         settings.sites[i].autoPopAdvancedFromApi = $('#toggle-' + settings.sites[i].id + '-advanced').prop('checked');
     }
 
-    setSettings(settings);
+    await setSettings(settings);
 };
 
 /**
@@ -390,7 +390,7 @@ async function setSettingsPropertiesFromIntegrationsForm() {
         settings.integrations[i].enabled = $('#toggle-' + settings.integrations[i].name).prop('checked');
     }
 
-    setSettings(settings);
+    await setSettings(settings);
 };
 
 /**
@@ -400,7 +400,7 @@ async function setSettingsPropertiesFromDebugForm() {
     const settings = await getSettings();
     settings.debug = $('#toggle-debug').prop('checked');
 
-    setSettings(settings);
+    await setSettings(settings);
 };
 
 /**

--- a/src/content/js/popup.js
+++ b/src/content/js/popup.js
@@ -15,13 +15,13 @@ $(async function () {
         // update enabled setting
         settings.enabled = !settings.enabled;
 
-        setSettings(settings, function() {
-            // update popup ui
-            setEnabledDisabledButtonState(settings);
+        await setSettings(settings);
 
-            // update icon
-            iconPort.postMessage({ x: "y" });
-        });
+        // update popup ui
+        setEnabledDisabledButtonState(settings);
+
+        // update icon
+        iconPort.postMessage({ x: "y" });
     });
 
     $('#btnSettings').click(async function() {

--- a/src/content/js/popup.js
+++ b/src/content/js/popup.js
@@ -5,22 +5,22 @@ var setEnabledDisabledButtonState = function(settings) {
     $('#toggleActive').html('<i class="fas fa-power-off"></i>&nbsp;&nbsp;&nbsp;&nbsp;' + (settings.enabled ? 'Disable' : '&nbsp;Enable'));
 };
 
-$(function () {
+$(async function () {
     // initialise page on load
-    getSettings(setEnabledDisabledButtonState);
+    const settings = await getSettings();
+    setEnabledDisabledButtonState(settings);
     
-    $('#toggleActive').click(function(e) {
-        getSettings(function(settings) {
-            // update enabled setting
-            settings.enabled = !settings.enabled;
+    $('#toggleActive').click(async function(e) {
+        const settings = await getSettings();
+        // update enabled setting
+        settings.enabled = !settings.enabled;
 
-            setSettings(settings, function() {
-                // update popup ui
-                setEnabledDisabledButtonState(settings);
+        setSettings(settings, function() {
+            // update popup ui
+            setEnabledDisabledButtonState(settings);
 
-                // update icon
-                iconPort.postMessage({ x: "y" });
-            });            
+            // update icon
+            iconPort.postMessage({ x: "y" });
         });
     });
 

--- a/src/eventPage.js
+++ b/src/eventPage.js
@@ -1,20 +1,18 @@
 browser.runtime.onConnect.addListener(function(port) {
     switch (port.name) {
         case 'init':
-            port.onMessage.addListener(function (request) {
-                getSettings(async function (settings) {
-                    await setIcon(settings);
-                    await browser.tabs.executeScript({ file: 'content/js/browser-polyfill.min.js' });
-                    await browser.tabs.executeScript({ file: 'content/js/content_script.js' });
-                });
+            port.onMessage.addListener(async function (request) {
+                const settings = await getSettings();
+                await setIcon(settings);
+                await browser.tabs.executeScript({ file: 'content/js/browser-polyfill.min.js' });
+                await browser.tabs.executeScript({ file: 'content/js/content_script.js' });
             });
             break;
 
         case 'icon':
-            port.onMessage.addListener(function (request) {
-                getSettings(async function (settings) {
-                    await setIcon(settings);
-                });
+            port.onMessage.addListener(async function (request) {
+                const settings = await getSettings();
+                await setIcon(settings);
             });
             break;
     }
@@ -53,16 +51,15 @@ async function buildMenus(settings) {
  * @param {*} info 
  * @param {*} tab 
  */
-function onClickHandler(info, tab) {
-    getSettings(async function (settings) {
-        for (var i = 0; i < settings.sites.length; i++) {
-            if (info.menuItemId == (settings.sites[i].id + 'Menu')) {
-                await browser.tabs.create({
-                    'url': settings.sites[i].domain.replace(/\/$/, '') + settings.sites[i].searchPath + encodeURIComponent(info.selectionText).replace(/\./g, ' ')
-                });
-            }
+async function onClickHandler(info, tab) {
+    const settings = await getSettings();
+    for (var i = 0; i < settings.sites.length; i++) {
+        if (info.menuItemId == (settings.sites[i].id + 'Menu')) {
+            await browser.tabs.create({
+                'url': settings.sites[i].domain.replace(/\/$/, '') + settings.sites[i].searchPath + encodeURIComponent(info.selectionText).replace(/\./g, ' ')
+            });
         }
-    });
+    }
 };
 
 browser.contextMenus.onClicked.addListener(onClickHandler);
@@ -70,10 +67,9 @@ browser.contextMenus.onClicked.addListener(onClickHandler);
 /**
  * set up context menu tree at install time.
  */
-browser.runtime.onInstalled.addListener(function () {
-    getSettings(function(settings) {
-        buildMenus(settings);
-    });
+browser.runtime.onInstalled.addListener(async function () {
+    const settings = await getSettings();
+    buildMenus(settings);
 });
 
 /**


### PR DESCRIPTION
Update our own APIs to be Promise-based. Resolves #44.

In scope:
- getSettings
- setSettings
- callApi

Testing done:

- MacOS, Firefox 87 ✅
  - Settings ✅
  - Advanced settings ✅
  - Options popup ✅
  - Icon shows up on websites ✅
- MacOS, Chrome 89 ✅
  - Settings ✅
  - Advanced settings ✅
  - Options popup ✅
  - Icon shows up on websites ✅