### PR TITLE
Update replace titles for allocine integration

### DIFF
--- a/src/content/js/content_script.js
+++ b/src/content/js/content_script.js
@@ -699,7 +699,44 @@
             search: {
                 containerSelector: 'meta[property="og:title"]',
                 selectorType: 'content',
-                modifiers: []
+                modifiers: 
+				[
+					{
+						type: 'replace',
+						from: 'critiques de la série ',
+						to: ''
+					},
+					{
+						type: 'replace',
+						from: 'les saisons de ',
+						to: ''
+					},
+					{
+						type: 'replace',
+						from: 'casting ',
+						to: ''
+					},
+					{
+						type: 'replace',
+						from: 'actus de la série ',
+						to: ''
+					},
+					{
+						type: 'replace',
+						from: 'vidéos ',
+						to: ''
+					},
+					{
+						type: 'replace',
+						from: ' en streaming',
+						to: ''
+					},
+					{
+						type: 'replace',
+						from: ' en vod',
+						to: ''
+					}
+				]
             },
             where: [
                 {
@@ -725,7 +762,60 @@
             search: {
                 containerSelector: 'meta[property="og:title"]',
                 selectorType: 'content',
-                modifiers: []
+                modifiers: 
+				[
+					{
+						type: 'replace',
+						from: 'avis sur le film ',
+						to: ''
+					},
+					{
+						type: 'replace',
+						from: 'séances ',
+						to: ''
+					},
+					{
+						type: 'replace',
+						from: 'actus du film ',
+						to: ''
+					},
+					{
+						type: 'replace',
+						from: 'bande-annonce vo ',
+						to: ''
+					},
+					{
+						type: 'replace',
+						from: 'tout le casting du film ',
+						to: ''
+					},
+					{
+						type: 'replace',
+						from: 'avis sur le film ',
+						to: ''
+					},
+					{
+						type: 'replace',
+						from: ': les critiques presse',
+						to: ''
+					},
+					{
+						type: 'replace',
+						from: 'photos et affiches du film ',
+						to: ''
+					},
+					{
+						type: 'replace',
+						from: 'les secrets de tournage du film ',
+						to: ''
+					},
+					{
+						type: 'replace',
+						from: 'les films similaires à ',
+						to: ''
+					}
+					
+				]
             },
             where: [
                 {


### PR DESCRIPTION
Hello,

In the allocine website, there are multiple tabs for each movie or show. The og:title meta property works directly only for the first tab. I added some replace modifiers to make it work better in other tabs too.