### PR TITLE
Fix bug where colon is replaced by "%3A" #196

### DIFF
--- a/src/content/js/content_script.js
+++ b/src/content/js/content_script.js
@@ -1510,7 +1510,7 @@ async function init() {
 
                                 log(['search term: ', searchTerm]);
 
-                                let searchUrl = site.domain.replace(/\/$/, '') + site.searchPath + encodeURIComponent(searchTerm).replace(/\./g, ' ');
+                                let searchUrl = site.domain.replace(/\/$/, '') + site.searchPath + encodeURIComponent(searchTerm).replace(/\./g, ' ').replace(/%3A/g, ':');
 
                                 log(['search url: ', searchUrl]);
 


### PR DESCRIPTION
This fixes the issue where the search is not automatically populating on Radarr and Sonarr:

"When opening Radarr/Sonarr from the respective icon on IMDb & TMDB, the search page is opened but the search field is not populated. The IMDB/TMDB reference appears in the url."

![image](https://github.com/user-attachments/assets/7dda6440-52a4-431f-a2b0-e7dc63b36ff4)

What should say 'imdb:tt0795176' is instead coming through as 'imdb%3Att0795176'.

This is because the searchTerm is being URI encoded:

https://github.com/trossr32/sonarr-radarr-lidarr-autosearch-browser-extension/blob/b56ef300c41ff7673700758d9117c6fbd4cb5bc7/src/content/js/content_script.js#L1513

This fix adds `.replace(/%3A/g, ':')` to `encodeURIComponent(searchTerm).replace(/\./g, ' ')` so '%3A' is replaced with a colon again.

Close #196 