### PR TITLE
fix Radarr/Sonarr `versionConfig` `searchPath` for versions 3-5+

### DIFF
--- a/src/content/js/core.js
+++ b/src/content/js/core.js
@@ -394,7 +394,7 @@ let sessionId,
                 },
                 {
                     versionMatch: /^[3|4|5|6]/,
-                    searchPath: '/add/new/',
+                    searchPath: '/add/new/?term=',
                     searchInputSelector: 'input[name="seriesLookup"]'
                 }
             ]

--- a/src/content/js/core.js
+++ b/src/content/js/core.js
@@ -409,7 +409,7 @@ let sessionId,
                 },
                 {
                     versionMatch: /^[3|4|5|6]/,
-                    searchPath: '/add/new/',
+                    searchPath: '/add/new/?term=',
                     searchInputSelector: 'input[name="movieLookup"]'
                 }
             ]

--- a/src/content/js/core.js
+++ b/src/content/js/core.js
@@ -403,7 +403,7 @@ let sessionId,
             id: 'radarr',
             configs: [
                 {
-                    versionMatch: /^0/,
+                    versionMatch: /^[0|2]/,
                     searchPath: '/addmovies/',
                     searchInputSelector: '.add-movies-search .x-movies-search'
                 },

--- a/src/content/js/options.js
+++ b/src/content/js/options.js
@@ -349,7 +349,7 @@ var initialiseAdvancedForm = function (settings) {
                     .append($('<li class="list-group-item pt-3 pb-5">' + 
                         '<h5 class="card-title pb-4">Radarr version config</h5>' + 
                         '<p class="card-text">These settings are defaulted to v4.<i>n</i>. For v0.<i>n</i> use:</p>' +
-                        '<p class="card-text">Search path url: <b>/addmmovies/</b></p>' +
+                        '<p class="card-text">Search path url: <b>/addmovies/</b></p>' +
                         '<p class="card-text">Search field selector: <b>.add-movies-search .x-movies-search</b></p>' +
                         '</li>'))
                 )


### PR DESCRIPTION
- fixes: https://github.com/trossr32/sonarr-radarr-lidarr-autosearch-browser-extension/issues/255

The 'auto populate from API' feature looks up a match in `versionConfig`. For Radarr/Sonarr, the `searchPath` for versions 3-5+ was `/add/new`, resulting in paths such as `/add/new/MYSEARCHTERM`; but [looking at the Radarr code](https://github.com/trossr32/sonarr-radarr-lidarr-autosearch-browser-extension/issues/255#issuecomment-2707822267) and the [Sonarr code](https://github.com/trossr32/sonarr-radarr-lidarr-autosearch-browser-extension/issues/255#issuecomment-2707879071), this was never valid, and it should actually be `/add/new?term=`, resulting in paths such as `/add/new?term=MYSEARCHTERM`

Workaround in the meantime:

- In the [extension options](chrome-extension://jmmjjcddjldjdjgckdiokhfokccdnekc/options.html)
  - Click on the 'Advanced' tab
  - Click the 'Auto populate from API' toggle for Radarr/Sonarr to make it 'Prevent auto populate'
  - Set the 'Search path URL' to `/add/new?term=`

I also mentioned the bug report + PR bug fix + workaround on the Chrome Extension reviews:

- https://chromewebstore.google.com/reviews/8edbfd6a-4fab-43c3-9d98-2b23e4200f71

This should also be a positive resolution for these reviews, which you might like to comment on once it's merged/published:

- https://chromewebstore.google.com/reviews/879deae8-9f9a-4d6b-bd34-5f9fe3ddd324
  - > Jhoan (1 star)
    > 8 July 2024
    > Used to work perfectly fine. Now it doesn't search at all. I can see the URL has the search query but nothing shows up in neither Radarr nor Sonarr.
- https://chromewebstore.google.com/reviews/02bc800b-88a8-4d14-8b01-93f524de2405
  - > Jeremy De Backer (3 stars)
    > 31 Oct 2024
    > Seems great, but doesn't work for me (and others according to reviews). It opens the *arr instance and adds 'add/new/imdb:ttxxxxxxx' to the url, but nothing happens.
- https://chromewebstore.google.com/reviews/20f44114-0e62-42f2-9dbc-fd6fbff76e65
  - > Ben Daniels (2 stars)
    > 2 Nov 2024
    > It gives the appearance that it will work, but as others have suggested, the search data in the url bar doesn't equate to a search within Radarr. The Radarr button on rotten tomatoes is unclickable. The Sonarr button on tvdb DOES function properly. 
    > 
    > I'll keep it installed and hope it gets an update. I do love the concept and have been looking for something just like this...