### PR TITLE
Support Firefox Android

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,9 @@
         "review": "grunt review",
         "chromium": "web-ext run -s dist/chromium -t chromium",
         "firefox": "web-ext run -s dist/firefox -t firefox-desktop",
-        "firefox:android": "web-ext run -s dist/firefox -t firefox-android"
+        "firefox:android": "web-ext run -s dist/firefox -t firefox-android",
+        "lint": "web-ext lint -s dist/firefox",
+        "lint:json": "npm run lint -- --output json --pretty"
     },
     "jest": {
         "verbose": true

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
         "playwright": "grunt playwright",
         "release": "grunt release",
         "review": "grunt review",
-        "firefox": "web-ext run -s dist/firefox -t firefox-desktop --devtools",
+        "chromium": "web-ext run -s dist/chromium -t chromium",
+        "firefox": "web-ext run -s dist/firefox -t firefox-desktop",
         "firefox:android": "web-ext run -s dist/firefox -t firefox-android"
     },
     "jest": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
         "gem": "^2.4.3"
     },
     "scripts": {
-        "test": "jest"
+        "test": "jest",
+        "release": "grunt release",
+        "firefox:android": "web-ext run -s dist/firefox -t firefox-android"
     },
     "jest": {
         "verbose": true

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
         "playwright": "grunt playwright",
         "release": "grunt release",
         "review": "grunt review",
+        "firefox": "web-ext run -s dist/firefox -t firefox-desktop --devtools",
         "firefox:android": "web-ext run -s dist/firefox -t firefox-android"
     },
     "jest": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,10 @@
     },
     "scripts": {
         "test": "jest",
+        "debug": "grunt debug",
+        "playwright": "grunt playwright",
         "release": "grunt release",
+        "review": "grunt review",
         "firefox:android": "web-ext run -s dist/firefox -t firefox-android"
     },
     "jest": {

--- a/src/content/js/core.js
+++ b/src/content/js/core.js
@@ -283,7 +283,7 @@ let sessionId,
         }, 
         config: {
             enabled: true,
-            contextMenu: true,
+            contextMenu: browser.contextMenus != null,
             debug: false,
             searchInputWaitForMs: 300,
             searchInputMaxAttempts: 20,

--- a/src/content/js/options.js
+++ b/src/content/js/options.js
@@ -182,10 +182,10 @@ var initialiseBasicForm = function (settings) {
                                 .append($('<label class="col-form-label">API key</label>'))
                             )
                             .append($('<div class="row"></div>')
-                                .append($('<div class="col-lg-7 col-8"></div>')
+                                .append($('<div class="col-7"></div>')
                                     .append($(`<input type="text" class="form-control" id="${site.id}ApiKey" data-site-id="${site.id}">`).val(site.apiKey))
                                 )
-                                .append($('<div class="col-lg-5 col-4"></div>')
+                                .append($('<div class="col-5"></div>')
                                     .append($(`<button id="${site.id}ApiKeyTest" type="button" class="btn btn-primary" data-site-id="${site.id}">` + 
                                         '<div style="float: left; margin-right: 10px;">Test</div>' + 
                                         `<div id="${site.id}ApiKeyIcon" style="float: left;"><i class="fab fa-cloudscale"></i></div>` + 

--- a/src/content/js/options.js
+++ b/src/content/js/options.js
@@ -627,24 +627,26 @@ var initialiseContextMenuForm = function (settings) {
         .append($('<div class="row"></div>')
             .append($('<label for="toggle-context-menu" class="col-4" style=margin-top: 2px;">Enable context menu</label>'))
             .append($('<div class="col"></div>')
-                .append($('<input type="checkbox" id="toggle-context-menu">').prop('checked', settings.config.contextMenu))
+                .append(browser.contextMenu ? $('<input type="checkbox" id="toggle-context-menu">').prop('checked', settings.config.contextMenu) : $('<span>Not supported in your browser.</span>'))
             )
         );
 
     $('#contextMenuOptionsForm').prepend(wrapper);
 
-    // enable toggle
-    $('#toggle-context-menu').bootstrapToggle({
-        on: 'Enabled',
-        off: 'Disabled',
-        onstyle: 'success',
-        offstyle: 'danger',
-        width: '90px',
-        size: 'small'
-    });
+    if (browser.contextMenu) {
+        // enable toggle
+        $('#toggle-context-menu').bootstrapToggle({
+            on: 'Enabled',
+            off: 'Disabled',
+            onstyle: 'success',
+            offstyle: 'danger',
+            width: '90px',
+            size: 'small'
+        });
 
-    // site enabled/disabled toggle change event
-    $('#toggle-context-menu').on('change', setSettingsPropertiesFromContextMenuForm);
+        // site enabled/disabled toggle change event
+        $('#toggle-context-menu').on('change', setSettingsPropertiesFromContextMenuForm);
+    }
 };
 
 /**
@@ -810,7 +812,8 @@ async function setSettingsPropertiesFromCustomIconForm() {
 async function setSettingsPropertiesFromContextMenuForm() {
     const settings = await getSettings();
 
-    settings.config.contextMenu = $('#toggle-context-menu').prop('checked');
+    const menu = $('#toggle-context-menu');
+    settings.config.contextMenu = menu != null ? menu.prop('checked') : false;
 
     await setSettings(settings);
 }

--- a/src/content/js/popup.js
+++ b/src/content/js/popup.js
@@ -1,32 +1,54 @@
 var iconPort = browser.runtime.connect({ name: 'icon' });
 
-var setEnabledDisabledButtonState = function(settings) {
+var initialiseEnabledDisabledButton = function(settings) {
     $('#toggleActive').removeClass('btn-success btn-danger').addClass(`btn-${(settings.config.enabled ? 'danger' : 'success')}`);
     $('#toggleActive').html(`<i class="fas fa-power-off"></i>&nbsp;&nbsp;&nbsp;&nbsp;${(settings.config.enabled ? 'Disable' : '&nbsp;Enable')}`);
+    iconPort.postMessage({ x: "y" });
 };
+
+browser.storage.onChanged.addListener(async function(changes, area) {
+    let changedItems = Object.keys(changes);
+
+    for (let item of changedItems) {
+        if (item !== 'sonarrRadarrLidarrAutosearchSettings') {
+            continue;
+        }
+
+        initialiseEnabledDisabledButton(changes[item].newValue);
+    }
+});
 
 $(async function () {
     // initialise page on load
     const settings = await getSettings();
 
-    setEnabledDisabledButtonState(settings);
-    
+    initialiseEnabledDisabledButton(settings);
+
     $('#toggleActive').on('click', async function(e) {
         const settings = await getSettings();
-        
-        // update enabled setting
         settings.config.enabled = !settings.config.enabled;
-
         await setSettings(settings);
-
-        // update popup ui
-        setEnabledDisabledButtonState(settings);
-
-        // update icon
-        iconPort.postMessage({ x: "y" });
     });
 
+    const isFirefox = typeof InstallTrigger !== 'undefined';
+    const isAndroid = /Android/i.test(navigator.userAgent);
+    
+    if (isFirefox && !isAndroid) {
+        $('#aSettings').on('click', function() {
+            // Allow the window to open before closing the popup
+            setTimeout(() => window.close(), 100);
+        });
+    } else {
+        $('#aSettings').hide();
+    }
+    
     $('#btnSettings').on('click', async function() {
-        await browser.runtime.openOptionsPage(); // add open flag in settings?
+        if (isFirefox && isAndroid) {
+            // Workaround for bug in Firefox Android
+            await browser.tabs.create({ url: browser.runtime.getURL("options.html") });
+        } else {
+            await browser.runtime.openOptionsPage();
+        }
+        window.close();
     });
 });

--- a/src/content/sass/options.scss
+++ b/src/content/sass/options.scss
@@ -41,6 +41,12 @@ a, a:focus, a:hover {
 
 .card-header {
     background-color: rgba(255,255,255,0.05);
+    
+    h4 {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
 }
 
 .card-integration {

--- a/src/content/sass/popup.scss
+++ b/src/content/sass/popup.scss
@@ -2,9 +2,3 @@ body {
     background-color: #1d1e22;
     color: #fff
 }
-
-.firefox-only { display: none; }
-
-@-moz-document url-prefix() {
-    .firefox-only { display: block; }
-}

--- a/src/content/sass/popup.scss
+++ b/src/content/sass/popup.scss
@@ -1,4 +1,0 @@
-body {
-    background-color: #1d1e22;
-    color: #fff
-}

--- a/src/content/sass/popup.scss
+++ b/src/content/sass/popup.scss
@@ -2,3 +2,9 @@ body {
     background-color: #1d1e22;
     color: #fff
 }
+
+.firefox-only { display: none; }
+
+@-moz-document url-prefix() {
+    .firefox-only { display: block; }
+}

--- a/src/eventPage.js
+++ b/src/eventPage.js
@@ -52,7 +52,7 @@ browser.runtime.onConnect.addListener(function(port) {
  * @param {Settings} settings 
  */
 async function buildMenus(settings) {
-    await browser.contextMenus.removeAll();
+    await browser.contextMenus?.removeAll();
 
     // if extension is disabled or context menu option is disabled gtfo
     if (!settings.config.enabled || !settings.config.contextMenu) {
@@ -67,11 +67,11 @@ async function buildMenus(settings) {
     }
 
     // create parent menu
-    browser.contextMenus.create({ "title": "Search Servarr", "id": "sonarrRadarrLidarr", "contexts": ["selection"] });
+    browser.contextMenus?.create({ "title": "Search Servarr", "id": "sonarrRadarrLidarr", "contexts": ["selection"] });
 
     // create child menus from enabled sites array
     for (let i = 0; i < enabledSites.length; i++) {
-        browser.contextMenus.create({ "title": enabledSites[i].menuText, "parentId": "sonarrRadarrLidarr", "id": `${enabledSites[i].id}Menu`, "contexts": ["selection"] });
+        browser.contextMenus?.create({ "title": enabledSites[i].menuText, "parentId": "sonarrRadarrLidarr", "id": `${enabledSites[i].id}Menu`, "contexts": ["selection"] });
     }
 }
 
@@ -92,7 +92,7 @@ async function onClickHandler(info, tab) {
     }
 };
 
-browser.contextMenus.onClicked.addListener(onClickHandler);
+browser.contextMenus?.onClicked.addListener(onClickHandler);
 
 /**
  * set up context menu tree at install time.

--- a/src/eventPage.js
+++ b/src/eventPage.js
@@ -52,10 +52,11 @@ browser.runtime.onConnect.addListener(function(port) {
  * @param {Settings} settings 
  */
 async function buildMenus(settings) {
+    // clear all before we decide to gtfo or not
     await browser.contextMenus?.removeAll();
 
-    // if extension is disabled or context menu option is disabled gtfo
-    if (!settings.config.enabled || !settings.config.contextMenu) {
+    // if unavailable, extension is disabled or context menu option is disabled gtfo
+    if (!browser.contextMenus || !settings.config.enabled || !settings.config.contextMenu) {
         return;
     }
 
@@ -67,11 +68,11 @@ async function buildMenus(settings) {
     }
 
     // create parent menu
-    browser.contextMenus?.create({ "title": "Search Servarr", "id": "sonarrRadarrLidarr", "contexts": ["selection"] });
+    browser.contextMenus.create({ "title": "Search Servarr", "id": "sonarrRadarrLidarr", "contexts": ["selection"] });
 
     // create child menus from enabled sites array
     for (let i = 0; i < enabledSites.length; i++) {
-        browser.contextMenus?.create({ "title": enabledSites[i].menuText, "parentId": "sonarrRadarrLidarr", "id": `${enabledSites[i].id}Menu`, "contexts": ["selection"] });
+        browser.contextMenus.create({ "title": enabledSites[i].menuText, "parentId": "sonarrRadarrLidarr", "id": `${enabledSites[i].id}Menu`, "contexts": ["selection"] });
     }
 }
 

--- a/src/manifest-firefox/manifest.json
+++ b/src/manifest-firefox/manifest.json
@@ -23,7 +23,7 @@
   },
   "options_ui": {
     "page": "options.html",
-    "open_in_tab": true
+    "open_in_tab": false
   },
   "background": {
     "scripts": [

--- a/src/manifest-firefox/manifest.json
+++ b/src/manifest-firefox/manifest.json
@@ -11,11 +11,15 @@
     "gecko": {
       "id": "sonarr-radarr-lidarr-autosearch@robgreen.me",
       "strict_min_version": "58.0"
+    },
+    "gecko_android": {
+      "strict_min_version": "68.0"
     }
   },
   "icons": {
     "16": "content/assets/images/SonarrRadarrLidarr16.png",
-    "48": "content/assets/images/SonarrRadarrLidarr48.png"
+    "48": "content/assets/images/SonarrRadarrLidarr48.png",
+    "128": "content/assets/images/SonarrRadarrLidarr128.png"
   },
   "options_ui": {
     "page": "options.html",

--- a/src/manifest-firefox/manifest.json
+++ b/src/manifest-firefox/manifest.json
@@ -10,10 +10,10 @@
   "browser_specific_settings": {
     "gecko": {
       "id": "sonarr-radarr-lidarr-autosearch@robgreen.me",
-      "strict_min_version": "58.0"
+      "strict_min_version": "113.0"
     },
     "gecko_android": {
-      "strict_min_version": "68.0"
+      "strict_min_version": "113.0"
     }
   },
   "icons": {

--- a/src/options.html
+++ b/src/options.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>Servarr autosearch options</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="content/css/bootstrap.min.css">
     <link rel="stylesheet" href="content/css/bootstrap4-toggle.min.css">
     <link rel="stylesheet" href="content/css/bootstrap-slider.min.css">
@@ -21,48 +22,48 @@
 <body>
 <div class="container">
     <div class="row" style="margin: 20px 0 35px 0;">
-        <div class="col-1">
-            <img src="content/assets/images/SonarrRadarrLidarr48.png" style="margin-right: 10px;" />
+        <div class="col-2 col-sm-1 d-flex align-items-center justify-content-center">
+            <img src="content/assets/images/SonarrRadarrLidarr48.png" class="img-fluid" style="max-width: 48px;" />
         </div>
-        <div class="col">
-            <h2>Servarr autosearch options</h2>
+        <div class="col-12 col-md-10 col-sm-11 d-flex align-items-center">
+            <h2 class="mb-0">Servarr autosearch options</h2>
         </div>
     </div>
 
-    <ul class="nav nav-tabs" id="settingsTabs" role="tablist">
+    <ul class="nav nav-tabs" id="settingsTabs" role="tablist" style="flex-wrap: wrap;">
         <li class="nav-item">
             <a class="nav-link active" id="basic-tab" data-bs-toggle="tab" href="#basic" role="tab" aria-controls="basic" aria-selected="true">
-                <i class="fas fa-cog"></i>&nbsp;&nbsp;&nbsp;Settings
+                <i class="fas fa-cog d-none d-sm-inline"></i><span class="d-none d-sm-inline">&nbsp;&nbsp;&nbsp;</span>Settings
             </a>
         </li>
         <li class="nav-item">
             <a class="nav-link" id="advanced-tab" data-bs-toggle="tab" href="#advanced" role="tab" aria-controls="advanced" aria-selected="false">
-                <i class="fas fa-exclamation-triangle"></i>&nbsp;&nbsp;&nbsp;Advanced
+                <i class="fas fa-exclamation-triangle d-none d-sm-inline"></i><span class="d-none d-sm-inline">&nbsp;&nbsp;&nbsp;</span>Advanced
             </a>
         </li>
         <li class="nav-item">
             <a class="nav-link" id="integrations-tab" data-bs-toggle="tab" href="#integrations" role="tab" aria-controls="integrations" aria-selected="false">
-                <i class="fas fa-link"></i>&nbsp;&nbsp;&nbsp;Integrations
+                <i class="fas fa-link d-none d-sm-inline"></i><span class="d-none d-sm-inline">&nbsp;&nbsp;&nbsp;</span>Integrations
             </a>
         </li>
         <li class="nav-item">
             <a class="nav-link" id="custom-icon-tab" data-bs-toggle="tab" href="#custom-icon" role="tab" aria-controls="custom-icon" aria-selected="false">
-                <i class="fas fa-arrows-alt"></i>&nbsp;&nbsp;&nbsp;Custom icons
+                <i class="fas fa-arrows-alt d-none d-sm-inline"></i><span class="d-none d-sm-inline">&nbsp;&nbsp;&nbsp;</span>Custom icons
             </a>
         </li>
         <li class="nav-item">
             <a class="nav-link" id="context-menu-tab" data-bs-toggle="tab" href="#context-menu" role="tab" aria-controls="context-menu" aria-selected="false">
-                <i class="fa fa-bars"></i>&nbsp;&nbsp;&nbsp;Context menu
+                <i class="fa fa-bars d-none d-sm-inline"></i><span class="d-none d-sm-inline">&nbsp;&nbsp;&nbsp;</span>Context menu
             </a>
         </li>
         <li class="nav-item">
             <a class="nav-link" id="debug-tab" data-bs-toggle="tab" href="#debug" role="tab" aria-controls="debug" aria-selected="false">
-                <i class="fa fa-bug"></i>&nbsp;&nbsp;&nbsp;Debug
+                <i class="fa fa-bug d-none d-sm-inline"></i><span class="d-none d-sm-inline">&nbsp;&nbsp;&nbsp;</span>Debug
             </a>
         </li>
         <li class="nav-item">
             <a class="nav-link" id="github-tab" data-bs-toggle="tab" href="#github" role="tab" aria-controls="github" aria-selected="false">
-                <i class="fab fa-github"></i>&nbsp;&nbsp;&nbsp;Github
+                <i class="fab fa-github d-none d-sm-inline"></i><span class="d-none d-sm-inline">&nbsp;&nbsp;&nbsp;</span>Github
             </a>
         </li>
         <li class="nav-item">
@@ -71,10 +72,10 @@
                 &nbsp;&nbsp;Keep me caffeinated
             </a>
         </li>
-    </ul>
+        </ul>
         
-    <div class="tab-content">
-        <div class="tab-pane fade show active" id="basic" role="tabpanel" aria-labelledby="basic-tab">
+        <div class="tab-content">
+            <div class="tab-pane fade show active" id="basic" role="tabpanel" aria-labelledby="basic-tab">
             <form id="generalOptionsForm"></form>
         </div>
         <div class="tab-pane fade" id="advanced" role="tabpanel" aria-labelledby="advanced-tab">
@@ -169,7 +170,7 @@
         </div>
         <div class="tab-pane fade" id="github" role="tabpanel" aria-labelledby="github-tab">
             <div class="row justify-content-md-center">
-                <div class="col-10" style="text-align: center">
+                <div class="col-12 col-md-10" style="text-align: center">
                     <h2 style="margin-bottom: 45px;">Contribute on GitHub</h2>
                     <h5 style="margin-bottom: 45px;">
                         This project is open source on Github: <a href="https://github.com/trossr32/sonarr-radarr-lidarr-autosearch">github.com/trossr32/sonarr-radarr-lidarr-autosearch</a>
@@ -182,7 +183,7 @@
         </div>
         <div class="tab-pane fade" id="donate" role="tabpanel" aria-labelledby="donate-tab">
             <div class="row justify-content-md-center">
-                <div class="col-10" style="text-align: center">
+                <div class="col-12 col-md-10" style="text-align: center">
                     <h2 style="margin-bottom: 45px;">Buy me a coffee</h2>
                     <h5 style="margin-bottom: 15px;">
                         If you found this extension useful and would like to buy me a coffee please click the link below

--- a/src/options.html
+++ b/src/options.html
@@ -25,8 +25,11 @@
         <div class="col-2 col-sm-1 d-flex align-items-center justify-content-center">
             <img src="content/assets/images/SonarrRadarrLidarr48.png" class="img-fluid" style="max-width: 48px;" />
         </div>
-        <div class="col-12 col-md-10 col-sm-11 d-flex align-items-center">
+        <div class="col-6 col-sm-8 d-flex align-items-center">
             <h2 class="mb-0">Servarr autosearch options</h2>
+        </div>
+        <div class="col-4 col-sm-3 d-flex mt-2 mt-sm-0">
+            <button type="button" class="btn btn-success w-100 px-1 px-md-2" id="toggleActive"><i class="fas fa-power-off"></i>&nbsp;&nbsp;Disable</button>
         </div>
     </div>
 

--- a/src/popup.html
+++ b/src/popup.html
@@ -33,7 +33,7 @@
 
     <div class="popupRow text-center">
         <button type="button" class="btn btn-primary popupBtn" id="btnSettings"><i class="fas fa-cogs"></i>&nbsp;&nbsp;&nbsp;Settings</button><br/>
-        <a href="options.html" target="_blank">Open Settings in a tab</a>
+        <a href="options.html" target="_blank" class="firefox-only">Open Settings in a tab</a>
     </div>
 
     <hr />

--- a/src/popup.html
+++ b/src/popup.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>Servarr autosearch options</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="content/css/bootstrap.min.css">
     <link rel="stylesheet" href="content/css/popup.css" />
     <script src="content/js/jquery.min.js"></script>
@@ -15,7 +16,7 @@
     <style type="text/css">
         .popupRow { width: 100%; margin-bottom: 10px; }
         .popupBtn { width: 70%; margin-bottom: 5px; }
-        .popupContainer { width: 35em; text-align: center; padding-top: 10px; }
+        .popupContainer { max-width: 35em; text-align: center; padding-top: 10px; }
     </style>
 </head>
 <body>
@@ -33,7 +34,7 @@
 
     <div class="popupRow text-center">
         <button type="button" class="btn btn-primary popupBtn" id="btnSettings"><i class="fas fa-cogs"></i>&nbsp;&nbsp;&nbsp;Settings</button><br/>
-        <a href="options.html" target="_blank" class="firefox-only">Open Settings in a tab</a>
+        <a href="options.html" target="_blank" id="aSettings">Open Settings in a tab</a>
     </div>
 
     <hr />

--- a/src/popup.html
+++ b/src/popup.html
@@ -14,7 +14,7 @@
     
     <style type="text/css">
         .popupRow { width: 100%; margin-bottom: 10px; }
-        .popupBtn { width: 70%; }
+        .popupBtn { width: 70%; margin-bottom: 5px; }
         .popupContainer { width: 35em; text-align: center; padding-top: 10px; }
     </style>
 </head>
@@ -32,7 +32,8 @@
     </div>
 
     <div class="popupRow text-center">
-        <button type="button" class="btn btn-primary popupBtn" id="btnSettings"><i class="fas fa-cogs"></i>&nbsp;&nbsp;&nbsp;Settings</button>
+        <button type="button" class="btn btn-primary popupBtn" id="btnSettings"><i class="fas fa-cogs"></i>&nbsp;&nbsp;&nbsp;Settings</button><br/>
+        <a href="options.html" target="_blank">Open Settings in a tab</a>
     </div>
 
     <hr />

--- a/src/popup.html
+++ b/src/popup.html
@@ -5,7 +5,6 @@
     <title>Servarr autosearch options</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="content/css/bootstrap.min.css">
-    <link rel="stylesheet" href="content/css/popup.css" />
     <script src="content/js/jquery.min.js"></script>
     <script src="content/js/browser-polyfill.min.js"></script>
     <script src="content/js/bootstrap.bundle.min.js"></script>
@@ -14,9 +13,11 @@
     <script src="content/js/all.min.js"></script>
     
     <style type="text/css">
+        body { background-color: #1d1e22; color: #fff }
         .popupRow { width: 100%; margin-bottom: 10px; }
         .popupBtn { width: 70%; margin-bottom: 5px; }
-        .popupContainer { max-width: 35em; text-align: center; padding-top: 10px; }
+        .popupContainer { width: 35em; max-width: 35em; text-align: center; padding-top: 10px; }
+        @-moz-document url-prefix() { .popupContainer { width: auto; } }
     </style>
 </head>
 <body>


### PR DESCRIPTION
I was missing the extension on Android (thank you for creating it), so I decided to install the .xpi myself, but it crashed. It turned out to be a quick fix, `browser.contextMenus` does not exist on Firefox Android, so I've updated the usages to handle it not being there and disabled the toggle if not available in the browser.

The rest of the changes in this PR are for making the Settings page behave on Firefox Android, desktop and Chrome - supporting the Extensions options view (and retaining tab view option), some minor tweaks for responsiveness, adding the Enabled/Disabled toggle to the top of the Settings page (and syncing changes with storage), etc - a light touch where possible to make it work without breaking anything. I also bumped the minimum Firefox version to 113.0 to remove some web-ext lint warnings about inaccessible APIs when parsing the manifest file.

Closes #113.

## Screenshots

### Firefox Android
<img width="200" height="220" alt="Firefox Android" src="https://github.com/user-attachments/assets/07dca301-3c1d-430e-be45-2fd09c145ff5" /><img width="200" height="220" alt="Firefox Android pop-up" src="https://github.com/user-attachments/assets/451627c1-2153-4a07-a028-f360fb5ea5df" /><img width="200" height="220" alt="image" src="https://github.com/user-attachments/assets/c29e5b52-f6ba-4262-9b90-b41afae59491" />

### Firefox desktop
<img width="200" height="80" alt="Firefox desktop extension in Extensions" src="https://github.com/user-attachments/assets/8de97128-3add-42f9-b967-aa7a146affa6" /><img width="150" height="80" alt="Firefox desktop popup" src="https://github.com/user-attachments/assets/125272e4-b606-4cd5-ac27-939fc8ecd884" />

### Chrome
<img width="200" height="80" alt="Chrome" src="https://github.com/user-attachments/assets/a01d25aa-fafb-44cb-9602-0f616dd874f8" />