### PR TITLE
fix senscritique adding deferMs option

### DIFF
--- a/src/content/engines/integrations/senscritique.js
+++ b/src/content/engines/integrations/senscritique.js
@@ -1,6 +1,6 @@
 (function(){
     if (!window.__servarrEngines) window.__servarrEngines = { list: [], helpers: {} };
-    
+
     var Def = window.__servarrEngines.helpers.DefaultEngine;
 
     var TV = Def({
@@ -11,10 +11,11 @@
         containerSelector: 'h1',
         insertWhere: 'prepend',
         iconStyle: 'width: 30px; margin: 0 10px 0 0;',
-        getSearch: function(_el,doc){ 
+        deferMs: 2000,
+        getSearch: function(_el,doc){
             var n=doc.querySelector('h1');
-                        
-            return (n && (n.textContent||'').trim())||''; 
+
+            return (n && (n.textContent||'').trim())||'';
         }
     });
 
@@ -26,9 +27,10 @@
         containerSelector: 'h1',
         insertWhere: 'prepend',
         iconStyle: 'width: 30px; margin: 0 10px 0 0;',
-        getSearch: function(_el,doc){ 
-            var n=doc.querySelector('h1'); 
-            return (n && (n.textContent||'').trim())||''; 
+        deferMs: 2000,
+        getSearch: function(_el,doc){
+            var n=doc.querySelector('h1');
+            return (n && (n.textContent||'').trim())||'';
         }
     });
 


### PR DESCRIPTION
 ## Problem

SensCritique.com updated their website to use Next.js with client-side rendering. The extension's content script was running before the h1 element (containing the movie/show title) was rendered, causing icon injection to fail.

## Solution

Added deferMs: 1000 to both Movie and TV show engines in senscritique.js. This 1 second delay allows the React/Next.js app to render the DOM before the extension attempts to inject icons.

## Changes

  - File: src/content/engines/integrations/senscritique.js
  - Change: Added deferMs: 1000 parameter to both TV and Movie engine configurations

  ## Testing

  Tested on:
  - Movie page: https://www.senscritique.com/film/bugonia/73084825 ✅
  - TV show page: https://www.senscritique.com/serie/adolescence/96415004 ✅

  Both Radarr (movies) and Sonarr (TV shows) icons now appear correctly after the page loads.