### PR TITLE
Select links with bdi child element for MusicBrainz entries if possible

### DIFF
--- a/src/content/engines/integrations/musicbrainz.js
+++ b/src/content/engines/integrations/musicbrainz.js
@@ -3,7 +3,10 @@
     
     var Def = window.__servarrEngines.helpers.DefaultEngine;
 
-    function getHref(sel, doc) { var a = doc.querySelector(sel); return (a && a.href) || ''; }
+    function getHref(sel, doc) {
+        var a = doc.querySelector(sel) || doc.querySelector(sel.replace(/:has\([^)]+\)/g, ''));
+        return (a && a.href) || '';
+    }
 
     var Artist = Def({
         id: 'musicbrainz',
@@ -14,7 +17,7 @@
         insertWhere: 'prepend',
         iconStyle: 'width: 26px; margin: 0 5px -4px 0;',
         getSearch: function (_el, doc) {
-            var href = getHref('.artistheader > h1 > a', doc);
+            var href = getHref('.artistheader > h1 a:has(bdi)', doc);
             return href ? href.replace('https://musicbrainz.org', '').replace('/artist/', 'lidarr:') : '';
         }
     });
@@ -28,7 +31,7 @@
         insertWhere: 'prepend',
         iconStyle: 'width: 26px; margin: 0 5px -4px 0;',
         getSearch: function (_el, doc) {
-            var href = getHref('.rgheader > h1 > a', doc);
+            var href = getHref('.rgheader > h1 a:has(bdi)', doc);
             return href ? href.replace('https://musicbrainz.org', '').replace('/release-group/', 'lidarr:') : '';
         }
     });
@@ -42,7 +45,7 @@
         insertWhere: 'prepend',
         iconStyle: 'width: 26px; margin: 0 5px -4px 0;',
         getSearch: function (_el, doc) {
-            var href = getHref('.releaseheader > h1 > a', doc);
+            var href = getHref('.releaseheader > h1 a:has(bdi)', doc);
             return href ? href.replace('https://musicbrainz.org', '').replace('/release/', 'lidarr:') : '';
         }
     });


### PR DESCRIPTION
I have the [Link Harmony release actions](https://github.com/kellnerd/musicbrainz-scripts#link-harmony-release-actions) UserScript in [Tampermonkey](https://www.tampermonkey.net), which adds a link to Harmony in the release header if it finds an entry on the site. The extension was picking this element up due to lack of selector specificity, so I've updated the extension logic to try to be more specific if we have browser support and fall back to the original behaviour if not (as the extension does support versions older than `:has` support goes back). I also removed the direct descendant `h1 > a` as it seems some pages wrap the `a` in a `span`, so I instead focused on the `bdi` child element, which all 3 seem to have from my testing - I've verified the test URLs in `musicbrainz.spec.ts` all still work.

Before (icon URL contains Harmony URL):
<img width="535" height="648" alt="Lidarr icon using Harmony URL from userscript element" src="https://github.com/user-attachments/assets/91de53c5-2811-4a3e-ab44-cf0b77e2fb74" />

After (correct Lidarr URL):
<img width="711" height="597" alt="Lidarr icon with correct URL" src="https://github.com/user-attachments/assets/4658b1c9-a534-4bbf-a4d1-f654659555ae" />