### PR TITLE
Fix symbol in RYM search and fix create_package_Grunt.sh

### DIFF
--- a/create_package_Grunt.sh
+++ b/create_package_Grunt.sh
@@ -16,7 +16,7 @@ fi
 
 mkdir -p Publish
 
-web-ext build -s dist/ -a Publish/ -o --filename "sonarr_radarr_lidarr_autosearch-{version}.xpi"
+web-ext build -s dist/firefox -a Publish/ -o --filename "sonarr_radarr_lidarr_autosearch-{version}.xpi"
 
 echo "###########################"
 echo "# Building chrome package"
@@ -26,4 +26,4 @@ echo
 ## This would be better as a copy of the xpi and simply renamed to have an extension of .zip, but
 ## I don't really know what I'm doing in .sh files ¯\_(ツ)_/¯
 
-web-ext build -s dist/ -a Publish/ -o --filename "sonarr_radarr_lidarr_autosearch-{version}.zip"
+web-ext build -s dist/chromium -a Publish/ -o --filename "sonarr_radarr_lidarr_autosearch-{version}.zip"

--- a/src/content/engines/integrations/rateyourmusic.js
+++ b/src/content/engines/integrations/rateyourmusic.js
@@ -12,8 +12,9 @@
         insertWhere: 'prepend',
         iconStyle: 'width: 20px; margin-right: 5px;',
         getSearch: function(_el,doc){ 
-            var n=doc.querySelector('.album_title'); 
-            return (n && (n.textContent||'').trim())||''; 
+            var qat = doc.querySelector('.album_title'); 
+            var album = (qat && (qat.textContent||'').split("  ")[0].trim())||''; 
+            return album; 
         }
     });
 


### PR DESCRIPTION
Fixing https://github.com/trossr32/sonarr-radarr-lidarr-autosearch-browser-extension/issues/317.

Edit: Removed code for Musicbrainz API. Lidarr text searches works now.