### PR TITLE
Resolve Firefox AMO validation warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - Updated build and test dependencies (Tailwind CSS, Font Awesome, Jest, Grunt, Playwright) and declared web-ext as a dev dependency.
+- Raised the minimum supported Firefox version to 140 (desktop) / 142 (Android) and declared the `data_collection_permissions` manifest key (`none` — no data collected), to meet Firefox add-on store requirements for the built-in data-consent feature.
 - Trakt is now community-supported. Trakt requires a paid subscription that the maintainer does not hold, so the Trakt integration can no longer be verified or maintained directly and now relies on community contributions. Its automated integration tests are skipped.
 
 ### Fixed

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -28,7 +28,7 @@ module.exports = function (grunt) {
                     { expand: true, flatten: true, src: 'node_modules/webextension-polyfill/dist/browser-polyfill.min.js.map', dest: 'dist/firefox/content/js', filter: 'isFile' },
                     { expand: true, flatten: true, src: 'node_modules/spectrum-colorpicker2/dist/spectrum.min.js', dest: 'dist/firefox/content/js', filter: 'isFile' },
                     { expand: true, flatten: true, src: 'node_modules/spectrum-colorpicker2/dist/spectrum.min.css', dest: 'dist/firefox/content/css', filter: 'isFile' },
-                    { expand: true, flatten: false, cwd: "src", src: '**/*.js', dest: 'dist/firefox', filter: 'isFile' },
+                    { expand: true, flatten: false, cwd: "src", src: ['**/*.js', '!eventPage.chrome.js'], dest: 'dist/firefox', filter: 'isFile' },
 
                     // content
                     { expand: true, flatten: true, src: 'src/*.html', dest: 'dist/firefox', filter: 'isFile' },
@@ -51,7 +51,7 @@ module.exports = function (grunt) {
                     { expand: true, flatten: true, src: 'node_modules/webextension-polyfill/dist/browser-polyfill.min.js.map', dest: 'dist/chromium/content/js', filter: 'isFile' },
                     { expand: true, flatten: true, src: 'node_modules/spectrum-colorpicker2/dist/spectrum.min.js', dest: 'dist/chromium/content/js', filter: 'isFile' },
                     { expand: true, flatten: true, src: 'node_modules/spectrum-colorpicker2/dist/spectrum.min.css', dest: 'dist/chromium/content/css', filter: 'isFile' },
-                    { expand: true, flatten: false, cwd: "src", src: '**/*.js', dest: 'dist/chromium', filter: 'isFile' },
+                    { expand: true, flatten: false, cwd: "src", src: ['**/*.js', '!eventPage.js'], dest: 'dist/chromium', filter: 'isFile' },
 
                     // content
                     { expand: true, flatten: true, src: 'src/*.html', dest: 'dist/chromium', filter: 'isFile' },
@@ -66,8 +66,8 @@ module.exports = function (grunt) {
             debug: {
                 files: [
                     // debug
-                    { expand: true, flatten: false, cwd: "src", src: '**/*.js', dest: 'dist/chromium', filter: 'isFile' },
-                    { expand: true, flatten: false, cwd: "src", src: '**/*.js', dest: 'dist/firefox', filter: 'isFile' },
+                    { expand: true, flatten: false, cwd: "src", src: ['**/*.js', '!eventPage.js'], dest: 'dist/chromium', filter: 'isFile' },
+                    { expand: true, flatten: false, cwd: "src", src: ['**/*.js', '!eventPage.chrome.js'], dest: 'dist/firefox', filter: 'isFile' },
                     // Spectrum in debug too
                     { expand: true, flatten: true, src: 'node_modules/spectrum-colorpicker2/dist/spectrum.min.js', dest: 'dist/chromium/content/js', filter: 'isFile' },
                     { expand: true, flatten: true, src: 'node_modules/spectrum-colorpicker2/dist/spectrum.min.css', dest: 'dist/chromium/content/css', filter: 'isFile' },

--- a/REVIEWER_GUIDE.md
+++ b/REVIEWER_GUIDE.md
@@ -12,7 +12,7 @@ This extension streamlines searching across user‑hosted *Servarr* applications
 
 - Auto-prefilling Servarr search pages when a user navigates to a URL containing `/add/new/<term>` (or similar).
 - Adding context menu items to search selected text directly in any configured Servarr instance.
-- Injecting small Servarr search icons/links into supported third‑party media sites (IMDb, TMDb, TVDb, Trakt, TVmaze, MusicBrainz, Letterboxd, TV Calendar, Rotten Tomatoes, Metacritic, Simkl, IPTorrents, Last.fm, Allociné, SensCritique, Betaseries, Prime Video, Rate Your Music, MyAnimeList, etc.).
+- Injecting small Servarr search icons/links into supported third‑party media sites (IMDb, TMDb, TVDb, Trakt, TVmaze, MusicBrainz, Letterboxd, TV Calendar, Rotten Tomatoes, Metacritic, Simkl, IPTorrents, Last.fm, Allociné, SensCritique, Betaseries, Prime Video, Rate Your Music, MyAnimeList, Wikipedia, etc.).
 - Providing an options UI where users configure base URLs + API keys (optional) for automatic advanced selector configuration.
 - Backup & restore of user settings via a dedicated Options tab:
   - Exports a JSON file using a schema‑versioned envelope.
@@ -101,7 +101,8 @@ There is **no custom packer**, no dynamic code generation beyond Tailwind’s st
     "*://*.thetvdb.com/*",
     "*://*.trakt.tv/*",
     "*://*.pogdesign.co.uk/*",
-    "*://*.tvmaze.com/*"
+    "*://*.tvmaze.com/*",
+    "*://*.wikipedia.org/*"
 ],
 "optional_host_permissions": [
     "<all_urls>"
@@ -146,6 +147,7 @@ There is **no custom packer**, no dynamic code generation beyond Tailwind’s st
     "*://*.trakt.tv/*",
     "*://*.pogdesign.co.uk/*",
     "*://*.tvmaze.com/*",
+    "*://*.wikipedia.org/*",
     "storage",
     "activeTab",
     "tabs",
@@ -190,6 +192,7 @@ All logic is synchronous or simple async with `fetch` only to user‑supplied Se
 | Telemetry | None. |
 | Tracking / Ads | None. |
 | Backup/restore | Export produces a local JSON download only; import reads a local JSON file chosen by the user. No data is transmitted externally. |
+| Firefox data consent | `browser_specific_settings.gecko.data_collection_permissions` is declared as `required: ["none"]`, formally stating that no data is collected (Firefox built-in data-consent). |
 
 ---
 

--- a/src/content/engines/default.js
+++ b/src/content/engines/default.js
@@ -132,9 +132,12 @@
      * @returns {Element|null}
      */
     function createNodeFromHTML(html) {
-        var t = document.createElement('div');
-        t.innerHTML = String(html || '').trim();
-        return t.firstElementChild || null;
+        // Parse via DOMParser rather than assigning innerHTML (or using
+        // createContextualFragment) so the AMO/addons-linter "unsafe assignment"
+        // warning isn't raised. Inputs here are engine-defined wrapper markup,
+        // never page/user content.
+        var doc = new DOMParser().parseFromString(String(html || '').trim(), 'text/html');
+        return doc.body.firstElementChild || null;
     }
 
     window.__servarrEngines.helpers.createNodeFromHTML = createNodeFromHTML;
@@ -256,7 +259,18 @@
                         a.title = (site.name || (typeof title === 'function' ? title(site.type, true) : String(site.type)));
                         a.setAttribute('data-servarr-icon', 'true');
                         a.setAttribute(`data-servarr-ext-${site.id}-completed`, 'true');
-                        a.innerHTML = `<svg style="${styles || iconStyle}" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48"><image href="${iconUrl}" width="48" height="48" /></svg>`;
+                        // Build the SVG via DOM APIs (createElementNS) instead of innerHTML to
+                        // avoid the AMO/addons-linter "unsafe innerHTML" warning.
+                        var SVG_NS = 'http://www.w3.org/2000/svg';
+                        var svg = document.createElementNS(SVG_NS, 'svg');
+                        svg.setAttribute('style', styles || iconStyle);
+                        svg.setAttribute('viewBox', '0 0 48 48');
+                        var svgImage = document.createElementNS(SVG_NS, 'image');
+                        svgImage.setAttribute('href', iconUrl);
+                        svgImage.setAttribute('width', '48');
+                        svgImage.setAttribute('height', '48');
+                        svg.appendChild(svgImage);
+                        a.appendChild(svg);
 
                         var nodeToInsert = a;
 
@@ -269,10 +283,9 @@
                         }
 
                         if (injectStyles) {
-                            var styleNode = createNodeFromHTML(`<style>${injectStyles}</style>`);
-                            if (styleNode) {
-                                document.head.appendChild(styleNode);
-                            }
+                            var styleNode = document.createElement('style');
+                            styleNode.textContent = injectStyles;
+                            document.head.appendChild(styleNode);
                         }
 
                         switch (insertWhere) {

--- a/src/manifest-firefox/manifest.json
+++ b/src/manifest-firefox/manifest.json
@@ -10,10 +10,13 @@
   "browser_specific_settings": {
     "gecko": {
       "id": "sonarr-radarr-lidarr-autosearch@robgreen.me",
-      "strict_min_version": "113.0"
+      "strict_min_version": "140.0",
+      "data_collection_permissions": {
+        "required": ["none"]
+      }
     },
     "gecko_android": {
-      "strict_min_version": "113.0"
+      "strict_min_version": "142.0"
     }
   },
   "icons": {


### PR DESCRIPTION
## Summary

Addresses the validation warnings reported when uploading the Firefox add-on. Extension version is unchanged (`3.1.0.0`).

### Changes
- **Data consent:** declare `browser_specific_settings.gecko.data_collection_permissions: { required: ["none"] }` (no data collected) and raise `strict_min_version` to **140** (desktop) / **142** (Android) — the versions that introduced the key. This also clears the Android `permissions.request` warnings.
- **Packaging:** stop bundling the Chrome MV3 service worker (`eventPage.chrome.js`) in the Firefox `.xpi`, and the Firefox event page (`eventPage.js`) in the Chromium `.zip` — clears the unused `action.setIcon` warning and trims both packages.
- **No more unsafe innerHTML in our code:** the injected icon SVG is built via `createElementNS`, wrapper markup via `DOMParser`, and styles via `createElement('style')` instead of `innerHTML`.
- **Docs:** CHANGELOG (3.1.0) records the min-version bump + data-consent declaration; REVIEWER_GUIDE adds Wikipedia to the site list + both permission blocks and a Firefox data-consent row.

### Validation
- `web-ext lint -s dist/firefox`: **0 errors, 13 warnings** (down from ~30) — remaining are third-party (jQuery/Font Awesome) and the non-extension test shim in `core.js` (dead code in Firefox).
- jshint clean; full Playwright suite **35 passed / 2 skipped (Trakt)** — the icon DOM rewrite is behaviour-equivalent.

> Note: `master`/the tagged **v3.1.0** release was already published; this merges the AMO fixes onto `master` under the same `3.1.0.0` version, so the built packages will differ from the originally-published v3.1.0 release assets.