### PR TITLE
fix(tvmaze): correct contextual show name selection on countdown/list pages

### DIFF
--- a/src/content/engines/integrations/tvmaze.js
+++ b/src/content/engines/integrations/tvmaze.js
@@ -11,9 +11,8 @@
         containerSelector: 'h1.show-for-medium',
         insertWhere: 'prepend',
         iconStyle: 'width: 32px; margin: -8px 10px 0 0;',
-        getSearch: function (_el, doc) {
-            var n = doc.querySelector('h1.show-for-medium');
-            return (n && (n.textContent || '').trim()) || '';
+        getSearch: function (el, doc) {
+            return (el && (el.textContent || '').trim()) || '';
         }
     });
 
@@ -25,9 +24,8 @@
         containerSelector: 'div.show-name',
         insertWhere: 'prepend',
         iconStyle: 'width: 24px; margin: -8px 10px 0 0;',
-        getSearch: function (_el, doc) {
-            var n = doc.querySelector('div.show-name');
-            return (n && (n.textContent || '').trim()) || '';
+        getSearch: function (el, doc) {
+            return (el && (el.textContent || '').trim()) || '';
         }
     });
 


### PR DESCRIPTION
This PR fixes a bug in the TVMaze integration where loading the countdown (or list) page causes the extension to inject the search icon with the first show's name for every show on the list.

**Problem:** 
The `getSearch` functions in `tvmaze.js` used global document queries (`doc.querySelector('...')`), which always return the first matching element on list/grid pages regardless of which item container was actually being processed.

**Solution:**
- Updated `getSearch` to use the contextual wrapper element (`el` / `_el`) passed into the function instead of querying the global `doc`.
- Cleans up parameter naming to match the `el` context.
