### PR TITLE
feat(tvmaze): add integration support for /shows directory listing pages

### DIFF
--- a/src/content/engines/integrations/tvmaze.js
+++ b/src/content/engines/integrations/tvmaze.js
@@ -31,5 +31,20 @@
         }
     });
 
-    window.__servarrEngines.list.push(ShowPage, Countdown);
+    var ShowsList = Def({
+        id: 'tvmaze',
+        key: 'tvmaze-shows',
+        match: function (doc, url) {
+            return url.indexOf('tvmaze.com/shows') >= 0 && url.indexOf('tvmaze.com/shows/') === -1;
+        },
+        siteType: 'sonarr',
+        containerSelector: 'span.title h2',
+        insertWhere: 'prepend',
+        iconStyle: 'width: 16px; height: 16px; margin: -2px 6px 0 0; display: inline-block; vertical-align: middle;',
+        getSearch: function (el, doc) {
+            return (el && (el.textContent || '').trim()) || '';
+        }
+    });
+
+    window.__servarrEngines.list.push(ShowPage, Countdown, ShowsList);
 })();

--- a/tests/playwright/site.integrations.tests/tvmaze.spec.ts
+++ b/tests/playwright/site.integrations.tests/tvmaze.spec.ts
@@ -20,3 +20,12 @@ test('tvmaze countdown has sonarr icons', async ({ page }) => {
 
   await expect(page.locator(iconDataLocator)).not.toHaveCount(0);
 });
+
+test('tvmaze shows directory has sonarr icons', async ({ page }) => {
+  await page.goto('https://www.tvmaze.com/shows', { waitUntil: 'commit' });
+
+  // Wait for the extension to inject (reloads if the MV3 service worker missed it)
+  await waitForServarrIcon(page);
+
+  await expect(page.locator(iconDataLocator)).not.toHaveCount(0);
+});


### PR DESCRIPTION
- Implement ShowsList engine targeting tvmaze.com/shows list pages.
- Add URL matcher to avoid conflicting with detail pages.
- Use smaller 16px search icons inside card headers.
- Add Playwright integration test case.